### PR TITLE
storing ZendeskError details

### DIFF
--- a/src/classes/ZendeskConnection.cls
+++ b/src/classes/ZendeskConnection.cls
@@ -19,6 +19,15 @@ global class ZendeskConnection {
     global class ZendeskError {
         global String error;
         global String description;
+        global Map<String, Object> details;
+        public ZendeskError(String jsonString) {
+            Map<String, Object> raw = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
+            error = (String)raw.get('error');
+            description = (String)raw.get('description');
+            if (null != raw.get('details')) {
+                details = (Map<String, Object>)raw.get('details');
+            }
+        }
     }
 
     // Factory method to initialize a ZendeskConnection with a Password
@@ -191,7 +200,7 @@ global class ZendeskConnection {
     private ZendeskError safeGetError(String resBody) {
         ZendeskError zerr = null;
         try {
-            zerr = (ZendeskError)JSON.deserialize(resBody, ZendeskError.class);
+            zerr = new ZendeskError(resBody);
         } catch(Exception e) {System.debug(e);}
         return zerr;
     }


### PR DESCRIPTION
i hit a bug where it was impossible to find out what's wrong with org record validation. so i decided to patch the code to store validation details.

here you can find more details on background:
https://developer.salesforce.com/forums?id=9060G000000XgUEQA0

here you can find the code i used to check if the change works in both cases: if there are details and if there is not:
https://gist.github.com/hlopetz/7c852ed12f8132742706653f09a8f1c8